### PR TITLE
fix: Improve error handling in OpenFeatureClient

### DIFF
--- a/src/OpenFeatureClient.php
+++ b/src/OpenFeatureClient.php
@@ -372,9 +372,10 @@ class OpenFeatureClient implements Client, LoggerAwareInterface
                 ),
             );
 
-            $error = $err instanceof ThrowableWithResolutionError ? $err->getResolutionError() : new ResolutionError(ErrorCode::GENERAL());
+            $error = $err instanceof ThrowableWithResolutionError ? $err->getResolutionError() : new ResolutionError(ErrorCode::GENERAL(), $err->getMessage());
 
             $details = (new EvaluationDetailsBuilder())
+                            ->withFlagKey($flagKey)
                             ->withValue($defaultValue)
                             ->withReason(Reason::ERROR)
                             ->withError($error)

--- a/tests/unit/OpenFeatureClientTest.php
+++ b/tests/unit/OpenFeatureClientTest.php
@@ -499,6 +499,7 @@ class OpenFeatureClientTest extends TestCase
         $resolutionError = $actualDetails->getError();
         $this->assertNotNull($resolutionError);
         $this->assertEquals($expectedErrorCode, $resolutionError->getResolutionErrorCode());
+        $this->assertEquals('flagKey', $actualDetails->getFlagKey());
     }
 
     /**
@@ -563,9 +564,14 @@ class OpenFeatureClientTest extends TestCase
         $client = new OpenFeatureClient($api, 'test-name', 'test-version');
         $client->setLogger($mockLogger);
 
-        $value = $client->getBooleanValue('flagKey', false);
+        $details = $client->getBooleanDetails('flagKey', false);
 
-        $this->assertEquals($value, false);
+        $this->assertEquals(false, $details->getValue());
+        $this->assertEquals('flagKey', $details->getFlagKey());
+
+        $this->assertInstanceOf(ResolutionError::class, $details->getError());
+        $this->assertEquals(ErrorCode::GENERAL(), $details->getError()->getResolutionErrorCode());
+        $this->assertEquals('NETWORK_ERROR', $details->getError()->getResolutionErrorMessage());
     }
 
     /**


### PR DESCRIPTION
## This PR

The PR adds the `flagKey` to EvaluationDetailsBuilder during error handling, providing more context for debugging. It also includes error message within the ResolutionError for more complete error information.

### How to test
Modify the NoOpProvider to throw any exception with a message. This should then propergate through to this new error handling