### PR TITLE
fix: Use late static binding in AbstractProvider

### DIFF
--- a/src/implementation/provider/AbstractProvider.php
+++ b/src/implementation/provider/AbstractProvider.php
@@ -23,7 +23,7 @@ abstract class AbstractProvider implements Provider
 
     public function getMetadata(): MetadataInterface
     {
-        return new Metadata(self::$NAME);
+        return new Metadata(static::$NAME);
     }
 
     abstract public function resolveBooleanValue(string $flagKey, bool $defaultValue, ?EvaluationContext $context = null): ResolutionDetailsInterface;

--- a/tests/TestProvider.php
+++ b/tests/TestProvider.php
@@ -4,26 +4,19 @@ declare(strict_types=1);
 
 namespace OpenFeature\Test;
 
-use OpenFeature\implementation\common\Metadata;
+use OpenFeature\implementation\provider\AbstractProvider;
 use OpenFeature\implementation\provider\ResolutionDetailsFactory;
-use OpenFeature\interfaces\common\Metadata as MetadataInterface;
 use OpenFeature\interfaces\flags\EvaluationContext;
 use OpenFeature\interfaces\hooks\HooksAwareTrait;
-use OpenFeature\interfaces\provider\Provider;
 use OpenFeature\interfaces\provider\ResolutionDetails;
 use Psr\Log\LoggerAwareTrait;
 
-class TestProvider implements Provider
+class TestProvider extends AbstractProvider
 {
     use HooksAwareTrait;
     use LoggerAwareTrait;
 
-    public const NAME = 'TestProvider';
-
-    public function getMetadata(): MetadataInterface
-    {
-        return new Metadata(self::NAME);
-    }
+    protected static string $NAME = 'TestProvider';
 
     /**
      * Resolves the flag value for the provided flag key as a boolean

--- a/tests/unit/HooksTest.php
+++ b/tests/unit/HooksTest.php
@@ -143,7 +143,6 @@ class HooksTest extends TestCase
                                     [$mutationHook],
                                     new HookHints(),
                                 );
-        // @phpstan-ignore-next-line
         $this->assertNull($additionalEvaluationContext);
     }
 
@@ -175,7 +174,6 @@ class HooksTest extends TestCase
                                     new HookHints(),
                                 );
 
-        //@phpstan-ignore-next-line
         $this->assertNull($additionalEvaluationContext);
     }
 
@@ -206,7 +204,6 @@ class HooksTest extends TestCase
                                     new HookHints(),
                                 );
 
-        // @phpstan-ignore-next-line
         $this->assertNull($additionalEvaluationContext);
     }
 


### PR DESCRIPTION
## This PR
Switches from self::$NAME to static::$NAME in the getMetadata method of the AbstractProvider class. This change is to ensure the name of the extending provider is used in the metadata. Previously, when extending from AbstractProvider, the metadata name was always AbstractProvider.

### How to test
Create a class that extends AbstractProvider, give it a different name, then call "getMetadata" and see that the name is now the name of the extended class and not "AbstractProvider"