### PR TITLE
fix: correct merging of contexts with targetingKey

### DIFF
--- a/src/implementation/flags/EvaluationContextMerger.php
+++ b/src/implementation/flags/EvaluationContextMerger.php
@@ -47,10 +47,10 @@ trait EvaluationContextMerger
 
                 /** @var ?string $newTargetingKey */
                 $newTargetingKey = null;
-                if (!is_null($calculatedTargetingKey) && strlen($calculatedTargetingKey) > 0) {
-                    $newTargetingKey = $calculatedTargetingKey;
-                } elseif (!is_null($additionalTargetingKey) && strlen($additionalTargetingKey) > 0) {
+                if (!is_null($additionalTargetingKey) && strlen($additionalTargetingKey) > 0) {
                     $newTargetingKey = $additionalTargetingKey;
+                } elseif (!is_null($calculatedTargetingKey) && strlen($calculatedTargetingKey) > 0) {
+                    $newTargetingKey = $calculatedTargetingKey;
                 }
 
                 $mergedAttributes = AttributesMerger::merge(

--- a/tests/unit/EvaluationContextTest.php
+++ b/tests/unit/EvaluationContextTest.php
@@ -127,4 +127,17 @@ class EvaluationContextTest extends TestCase
 
         $this->assertEquals($expectedEvaluationContextAttributes, $actualEvaluationContextAttributes);
     }
+
+    public function testEvaluationContextMergingTargetingKey(): void
+    {
+        $firstEvaluationContext = new EvaluationContext('default');
+        $secondEvaluationContext = new EvaluationContext('merged_key');
+
+        $expectedEvaluationContextAttributes = 'merged_key';
+
+        $actualEvaluationContext = EvaluationContext::merge($firstEvaluationContext, $secondEvaluationContext);
+        $actualEvaluationContextAttributes = $actualEvaluationContext->getTargetingKey();
+
+        $this->assertEquals($expectedEvaluationContextAttributes, $actualEvaluationContextAttributes);
+    }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Corrects the behavior of EvaluationContextMerger `merge()` when using string `targetingKey`.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #135 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

The `testEvaluationContextMergingTargetingKey` test in EvaluationContextTest.php has been added. The test fails without the proposed fix, as expected.

