### PR TITLE
ci: Run tests on PHP 8.3 & 8.4

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Adds PHP 8.3 & 8.4 to the PR CI workflow.

### Notes
Would be good to ensure everything still works on recent PHP versions.

An open PR for adding PHP 8.3 to the CI matrix exists: https://github.com/open-feature/php-sdk/pull/126

