### PR TITLE
feat: support isolated API instances

### DIFF
--- a/src/OpenFeatureAPI.php
+++ b/src/OpenFeatureAPI.php
@@ -55,8 +55,12 @@ final class OpenFeatureAPI implements API, LoggerAwareInterface
      * It's important that multiple instances of the API not be active, so that state stored therein, such as the registered provider, static global
      * evaluation context, and globally configured hooks allow the API to behave predictably. This can be difficult in some runtimes or languages, but
      * implementors should make their best effort to ensure that only a single instance of the API is used.
+     *
+     * For isolated instances, prefer using the factory function in OpenFeature\isolated.
+     *
+     * @see \OpenFeature\isolated\OpenFeatureAPIFactory::createAPI()
      */
-    private function __construct()
+    public function __construct()
     {
         $this->provider = new NoOpProvider();
     }

--- a/src/isolated/OpenFeatureAPIFactory.php
+++ b/src/isolated/OpenFeatureAPIFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenFeature\isolated;
+
+use OpenFeature\OpenFeatureAPI;
+use OpenFeature\interfaces\flags\API;
+
+/**
+ * Factory for creating isolated OpenFeature API instances.
+ *
+ * -----------------
+ * Requirement 1.8.1
+ * -----------------
+ * The API MUST expose a factory function which creates and returns a new,
+ * independent instance of the API.
+ *
+ * Each instance returned by this factory function maintains its own state,
+ * including providers, evaluation context, hooks, and event handlers.
+ * Instances created by the factory function do not share state with the
+ * "default" global singleton or with each other.
+ *
+ * -----------------
+ * Requirement 1.8.3
+ * -----------------
+ * The factory function for creating isolated instances SHOULD be housed in a
+ * distinct module, import path, package, or namespace from the global
+ * singleton API.
+ *
+ * @see https://openfeature.dev/specification/sections/flag-evaluation#18-isolated-api-instances
+ */
+final class OpenFeatureAPIFactory
+{
+    /**
+     * Creates a new, independent API instance with fully isolated state.
+     *
+     * Usage:
+     *   $api = OpenFeatureAPIFactory::createAPI();
+     *   $api->setProvider(new MyProvider());
+     *   $client = $api->getClient();
+     */
+    public static function createAPI(): API
+    {
+        return new OpenFeatureAPI();
+    }
+}

--- a/src/isolated/OpenFeatureAPIFactory.php
+++ b/src/isolated/OpenFeatureAPIFactory.php
@@ -29,6 +29,9 @@ use OpenFeature\interfaces\flags\API;
  * singleton API.
  *
  * @see https://openfeature.dev/specification/sections/flag-evaluation#18-isolated-api-instances
+ *
+ * @experimental Section 1.8 of the OpenFeature specification is experimental
+ *               and subject to change.
  */
 final class OpenFeatureAPIFactory
 {
@@ -39,6 +42,9 @@ final class OpenFeatureAPIFactory
      *   $api = OpenFeatureAPIFactory::createAPI();
      *   $api->setProvider(new MyProvider());
      *   $client = $api->getClient();
+     *
+     * @experimental Section 1.8 of the OpenFeature specification is experimental
+     *               and subject to change.
      */
     public static function createAPI(): API
     {

--- a/tests/unit/IsolatedAPITest.php
+++ b/tests/unit/IsolatedAPITest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenFeature\Test\unit;
 
 use OpenFeature\OpenFeatureAPI;
+use OpenFeature\Test\APITestHelper;
 use OpenFeature\Test\TestCase;
 use OpenFeature\Test\TestHook;
 use OpenFeature\Test\TestProvider;
@@ -21,40 +22,37 @@ class IsolatedAPITest extends TestCase
      * The API MUST expose a factory function which creates and returns a new,
      * independent instance of the API.
      */
-    public function testFactoryCreatesNewAPIInstance(): void
-    {
-        $api = OpenFeatureAPIFactory::createAPI();
-
-        $this->assertInstanceOf(API::class, $api);
-        $this->assertInstanceOf(OpenFeatureAPI::class, $api);
-    }
-
-    /**
-     * Requirement 1.8.1
-     *
-     * Each instance returned by this factory function maintains its own state.
-     * Instances created by the factory function do not share state with the
-     * "default" global singleton or with each other.
-     */
     public function testFactoryCreatesDistinctInstances(): void
     {
         $api1 = OpenFeatureAPIFactory::createAPI();
         $api2 = OpenFeatureAPIFactory::createAPI();
 
+        $this->assertInstanceOf(API::class, $api1);
+        $this->assertInstanceOf(OpenFeatureAPI::class, $api1);
         $this->assertNotSame($api1, $api2);
     }
 
     /**
      * Requirement 1.8.1
      *
-     * Instances do not share state with the "default" global singleton.
+     * Isolated instances do not share state with the global singleton and
+     * mutating an isolated instance does not affect the singleton's state.
      */
-    public function testIsolatedInstanceIsNotTheSingleton(): void
+    public function testIsolatedInstanceDoesNotInterfereWithSingleton(): void
     {
-        $singleton = OpenFeatureAPI::getInstance();
+        $singleton = APITestHelper::new();
         $isolated = OpenFeatureAPIFactory::createAPI();
 
         $this->assertNotSame($singleton, $isolated);
+
+        // Mutate the isolated instance
+        $isolated->setProvider(new TestProvider());
+        $isolated->addHooks(new TestHook());
+        $isolated->setEvaluationContext(new EvaluationContext('isolated-key'));
+
+        // Singleton state remains unchanged
+        $this->assertInstanceOf(NoOpProvider::class, $singleton->getProvider());
+        $this->assertEmpty($singleton->getHooks());
     }
 
     /**
@@ -96,14 +94,13 @@ class IsolatedAPITest extends TestCase
      */
     public function testProviderIsolation(): void
     {
-        $singleton = OpenFeatureAPI::getInstance();
-        $singleton->setProvider(new NoOpProvider());
+        $api1 = OpenFeatureAPIFactory::createAPI();
+        $api2 = OpenFeatureAPIFactory::createAPI();
 
-        $isolated = OpenFeatureAPIFactory::createAPI();
-        $isolated->setProvider(new TestProvider());
+        $api1->setProvider(new TestProvider());
 
-        $this->assertInstanceOf(NoOpProvider::class, $singleton->getProvider());
-        $this->assertInstanceOf(TestProvider::class, $isolated->getProvider());
+        $this->assertInstanceOf(TestProvider::class, $api1->getProvider());
+        $this->assertInstanceOf(NoOpProvider::class, $api2->getProvider());
     }
 
     /**
@@ -113,15 +110,14 @@ class IsolatedAPITest extends TestCase
      */
     public function testHookIsolation(): void
     {
-        $singleton = OpenFeatureAPI::getInstance();
-        $singleton->clearHooks();
+        $api1 = OpenFeatureAPIFactory::createAPI();
+        $api2 = OpenFeatureAPIFactory::createAPI();
 
-        $isolated = OpenFeatureAPIFactory::createAPI();
         $hook = new TestHook();
-        $isolated->addHooks($hook);
+        $api1->addHooks($hook);
 
-        $this->assertEmpty($singleton->getHooks());
-        $this->assertCount(1, $isolated->getHooks());
+        $this->assertCount(1, $api1->getHooks());
+        $this->assertEmpty($api2->getHooks());
     }
 
     /**
@@ -131,41 +127,38 @@ class IsolatedAPITest extends TestCase
      */
     public function testEvaluationContextIsolation(): void
     {
-        $singleton = OpenFeatureAPI::getInstance();
-        $singletonContext = new EvaluationContext('singleton-key');
-        $singleton->setEvaluationContext($singletonContext);
+        $api1 = OpenFeatureAPIFactory::createAPI();
+        $api2 = OpenFeatureAPIFactory::createAPI();
 
-        $isolated = OpenFeatureAPIFactory::createAPI();
-        $isolatedContext = new EvaluationContext('isolated-key');
-        $isolated->setEvaluationContext($isolatedContext);
+        $api1->setEvaluationContext(new EvaluationContext('key-1'));
+        $api2->setEvaluationContext(new EvaluationContext('key-2'));
 
-        $actualSingletonContext = $singleton->getEvaluationContext();
-        $actualIsolatedContext = $isolated->getEvaluationContext();
+        $ctx1 = $api1->getEvaluationContext();
+        $ctx2 = $api2->getEvaluationContext();
 
-        $this->assertNotNull($actualSingletonContext);
-        $this->assertNotNull($actualIsolatedContext);
-        $this->assertEquals('singleton-key', $actualSingletonContext->getTargetingKey());
-        $this->assertEquals('isolated-key', $actualIsolatedContext->getTargetingKey());
+        $this->assertNotNull($ctx1);
+        $this->assertNotNull($ctx2);
+        $this->assertEquals('key-1', $ctx1->getTargetingKey());
+        $this->assertEquals('key-2', $ctx2->getTargetingKey());
     }
 
     /**
      * Requirement 1.8.2
      *
-     * An isolated API instance is functionally equivalent to the global
-     * singleton. A client obtained from an isolated instance behaves
-     * identically to a client from the global singleton.
+     * A client obtained from an isolated instance uses that instance's provider.
      */
-    public function testClientFromIsolatedInstanceUsesIsolatedProvider(): void
+    public function testClientUsesItsOwnInstanceProvider(): void
     {
-        $isolated = OpenFeatureAPIFactory::createAPI();
-        $provider = new TestProvider();
-        $isolated->setProvider($provider);
+        $api1 = OpenFeatureAPIFactory::createAPI();
+        $api2 = OpenFeatureAPIFactory::createAPI();
 
-        $client = $isolated->getClient('test', '1.0');
-        $result = $client->getBooleanValue('flag-key', false);
+        $api1->setProvider(new TestProvider());
 
-        // TestProvider returns the default value
-        $this->assertFalse($result);
+        $client1 = $api1->getClient('test', '1.0');
+        $client2 = $api2->getClient('test', '1.0');
+
+        $this->assertFalse($client1->getBooleanValue('flag-key', false));
+        $this->assertFalse($client2->getBooleanValue('flag-key', false));
     }
 
     /**

--- a/tests/unit/IsolatedAPITest.php
+++ b/tests/unit/IsolatedAPITest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenFeature\Test\unit;
+
+use OpenFeature\OpenFeatureAPI;
+use OpenFeature\Test\TestCase;
+use OpenFeature\Test\TestHook;
+use OpenFeature\Test\TestProvider;
+use OpenFeature\implementation\flags\EvaluationContext;
+use OpenFeature\implementation\provider\NoOpProvider;
+use OpenFeature\interfaces\flags\API;
+use OpenFeature\isolated\OpenFeatureAPIFactory;
+
+class IsolatedAPITest extends TestCase
+{
+    /**
+     * Requirement 1.8.1
+     *
+     * The API MUST expose a factory function which creates and returns a new,
+     * independent instance of the API.
+     */
+    public function testFactoryCreatesNewAPIInstance(): void
+    {
+        $api = OpenFeatureAPIFactory::createAPI();
+
+        $this->assertInstanceOf(API::class, $api);
+        $this->assertInstanceOf(OpenFeatureAPI::class, $api);
+    }
+
+    /**
+     * Requirement 1.8.1
+     *
+     * Each instance returned by this factory function maintains its own state.
+     * Instances created by the factory function do not share state with the
+     * "default" global singleton or with each other.
+     */
+    public function testFactoryCreatesDistinctInstances(): void
+    {
+        $api1 = OpenFeatureAPIFactory::createAPI();
+        $api2 = OpenFeatureAPIFactory::createAPI();
+
+        $this->assertNotSame($api1, $api2);
+    }
+
+    /**
+     * Requirement 1.8.1
+     *
+     * Instances do not share state with the "default" global singleton.
+     */
+    public function testIsolatedInstanceIsNotTheSingleton(): void
+    {
+        $singleton = OpenFeatureAPI::getInstance();
+        $isolated = OpenFeatureAPIFactory::createAPI();
+
+        $this->assertNotSame($singleton, $isolated);
+    }
+
+    /**
+     * Requirement 1.8.2
+     *
+     * Instances returned by the factory function MUST conform to the same API
+     * contract as the global singleton, including flag evaluation, provider
+     * management, context, hooks, events, and shutdown functionality.
+     */
+    public function testIsolatedInstanceConformsToAPIContract(): void
+    {
+        $api = OpenFeatureAPIFactory::createAPI();
+
+        // Provider management
+        $provider = new TestProvider();
+        $api->setProvider($provider);
+        $this->assertSame($provider, $api->getProvider());
+        $this->assertEquals($provider->getMetadata(), $api->getProviderMetadata());
+
+        // Hooks
+        $hook = new TestHook();
+        $api->addHooks($hook);
+        $this->assertEquals([$hook], $api->getHooks());
+
+        // Evaluation context
+        $context = new EvaluationContext('targeting-key');
+        $api->setEvaluationContext($context);
+        $this->assertSame($context, $api->getEvaluationContext());
+
+        // Client creation
+        $client = $api->getClient('test-domain', '1.0.0');
+        $this->assertEquals('test-domain', $client->getMetadata()->getName());
+    }
+
+    /**
+     * Requirement 1.8.1
+     *
+     * Providers are isolated between instances.
+     */
+    public function testProviderIsolation(): void
+    {
+        $singleton = OpenFeatureAPI::getInstance();
+        $singleton->setProvider(new NoOpProvider());
+
+        $isolated = OpenFeatureAPIFactory::createAPI();
+        $isolated->setProvider(new TestProvider());
+
+        $this->assertInstanceOf(NoOpProvider::class, $singleton->getProvider());
+        $this->assertInstanceOf(TestProvider::class, $isolated->getProvider());
+    }
+
+    /**
+     * Requirement 1.8.1
+     *
+     * Hooks are isolated between instances.
+     */
+    public function testHookIsolation(): void
+    {
+        $singleton = OpenFeatureAPI::getInstance();
+        $singleton->clearHooks();
+
+        $isolated = OpenFeatureAPIFactory::createAPI();
+        $hook = new TestHook();
+        $isolated->addHooks($hook);
+
+        $this->assertEmpty($singleton->getHooks());
+        $this->assertCount(1, $isolated->getHooks());
+    }
+
+    /**
+     * Requirement 1.8.1
+     *
+     * Evaluation context is isolated between instances.
+     */
+    public function testEvaluationContextIsolation(): void
+    {
+        $singleton = OpenFeatureAPI::getInstance();
+        $singletonContext = new EvaluationContext('singleton-key');
+        $singleton->setEvaluationContext($singletonContext);
+
+        $isolated = OpenFeatureAPIFactory::createAPI();
+        $isolatedContext = new EvaluationContext('isolated-key');
+        $isolated->setEvaluationContext($isolatedContext);
+
+        $actualSingletonContext = $singleton->getEvaluationContext();
+        $actualIsolatedContext = $isolated->getEvaluationContext();
+
+        $this->assertNotNull($actualSingletonContext);
+        $this->assertNotNull($actualIsolatedContext);
+        $this->assertEquals('singleton-key', $actualSingletonContext->getTargetingKey());
+        $this->assertEquals('isolated-key', $actualIsolatedContext->getTargetingKey());
+    }
+
+    /**
+     * Requirement 1.8.2
+     *
+     * An isolated API instance is functionally equivalent to the global
+     * singleton. A client obtained from an isolated instance behaves
+     * identically to a client from the global singleton.
+     */
+    public function testClientFromIsolatedInstanceUsesIsolatedProvider(): void
+    {
+        $isolated = OpenFeatureAPIFactory::createAPI();
+        $provider = new TestProvider();
+        $isolated->setProvider($provider);
+
+        $client = $isolated->getClient('test', '1.0');
+        $result = $client->getBooleanValue('flag-key', false);
+
+        // TestProvider returns the default value
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Requirement 1.8.1
+     *
+     * clearHooks on one instance does not affect another.
+     */
+    public function testClearHooksDoesNotAffectOtherInstances(): void
+    {
+        $api1 = OpenFeatureAPIFactory::createAPI();
+        $api2 = OpenFeatureAPIFactory::createAPI();
+
+        $hook = new TestHook();
+        $api1->addHooks($hook);
+        $api2->addHooks($hook);
+
+        $api1->clearHooks();
+
+        $this->assertEmpty($api1->getHooks());
+        $this->assertCount(1, $api2->getHooks());
+    }
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
This PR introduces support for creating isolated OpenFeature API instances, each with their own providers, hooks, context, and event handling - enabling multi-tenant or side-by-side usage without shared global state.

### Related Issues
Fixes https://github.com/open-feature/php-sdk/issues/170

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

