### PR TITLE
docs: fix inaccuracies in README code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ function example()
 #### Extended Example
 
 ```php
+use OpenFeature\OpenFeatureAPI;
 use OpenFeature\OpenFeatureClient;
 
 class MyClass 
@@ -173,14 +174,14 @@ If the flag management system you're using supports targeting, you can provide t
 ```php
 // add a value to the global context
 $api = OpenFeatureAPI::getInstance();
-$api->setEvaluationContext(new EvaluationContext('targetingKey', ['myGlobalKey' => 'myGlobalValue']));
+$api->setEvaluationContext(new EvaluationContext('targetingKey', new Attributes(['myGlobalKey' => 'myGlobalValue'])));
 
 // add a value to the client context
 $client = $api->getClient();
-$client->setEvaluationContext(new EvaluationContext('targetingKey', ['myClientKey' => 'myClientValue']));
+$client->setEvaluationContext(new EvaluationContext('targetingKey', new Attributes(['myClientKey' => 'myClientValue'])));
 
 // add a value to the invocation context
-$context = new EvaluationContext('targetingKey', ['myInvocationKey' => 'myInvocationValue']);
+$context = new EvaluationContext('targetingKey', new Attributes(['myInvocationKey' => 'myInvocationValue']));
 
 $boolValue = $client->getBooleanValue('boolFlag', false, $context);
 ```
@@ -196,11 +197,11 @@ Once you've added a hook as a dependency, it can be registered at the global, cl
 ```php
 // add a hook globally, to run on all evaluations
 $api = OpenFeatureAPI::getInstance();
-$api->addHook(new ExampleGlobalHook());
+$api->addHooks(new ExampleGlobalHook());
 
 // add a hook on this client, to run on all evaluations made by this client
 $client = $api->getClient();
-$client->addHook(new ExampleClientHook());
+$client->addHooks(new ExampleClientHook());
 
 // add a hook for this evaluation only
 $value = $client->getBooleanValue("boolFlag", false, $context, new EvaluationOptions([new ExampleInvocationHook()]));
@@ -336,8 +337,9 @@ declare(strict_types=1);
 
 namespace OpenFeature\Example\Providers;
 
+use OpenFeature\implementation\provider\AbstractProvider;
 use OpenFeature\interfaces\flags\EvaluationContext;
-use OpenFeature\interfaces\provider\ResolutionDetails;
+use OpenFeature\interfaces\provider\ResolutionDetails as ResolutionDetailsInterface;
 
 class ExampleProviderExtension extends AbstractProvider
 {
@@ -379,9 +381,9 @@ class ExampleProviderExtension extends AbstractProvider
 
 To develop a hook, you need to create a new project and include the OpenFeature SDK as a dependency.
 This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/php-sdk-contrib) available under the OpenFeature organization.
-Implement your own hook by conforming to the `Hook interface`.
-To satisfy the interface, all methods (`Before`/`After`/`Finally`/`Error`) need to be defined.
-To avoid defining empty functions, make use of the `UnimplementedHook` struct (which already implements all the empty functions).
+Implement your own hook by conforming to the `Hook` interface.
+To satisfy the interface, all methods (`before`/`after`/`finally`/`error`) need to be defined.
+You can also extend one of the typed abstract base classes (`BooleanHook`, `StringHook`, `IntegerHook`, `FloatHook`, `ObjectHook`) which automatically implement `supportsFlagValueType()` for the corresponding flag type.
 
 ```php
 declare(strict_types=1);
@@ -394,6 +396,7 @@ use OpenFeature\interfaces\hooks\Hook;
 use OpenFeature\interfaces\hooks\HookContext;
 use OpenFeature\interfaces\hooks\HookHints;
 use OpenFeature\interfaces\provider\ResolutionDetails;
+use Throwable;
 
 
 class ExampleStringHookImplementation implements Hook
@@ -436,6 +439,7 @@ use OpenFeature\interfaces\flags\FlagValueType;
 use OpenFeature\interfaces\hooks\HookContext;
 use OpenFeature\interfaces\hooks\HookHints;
 use OpenFeature\interfaces\provider\ResolutionDetails;
+use Throwable;
 
 
 class ExampleStringHookExtension extends StringHook


### PR DESCRIPTION
## Summary

- Fix code examples in the README that would throw errors at runtime if copy-pasted
- Replace references to non-existent `UnimplementedHook` and Go SDK terminology

## Changes

1. **Targeting section**: Fixed `new EvaluationContext('targetingKey', [...])` to `new EvaluationContext('targetingKey', new Attributes([...]))`. The constructor's second argument is typed `?AttributesInterface`, so passing a plain array throws a `TypeError`. Applied to all three `EvaluationContext` instantiations
2. **Hooks section**: Fixed `$api->addHook(...)` and `$client->addHook(...)` (singular) to `addHooks(...)` (plural). Only the plural method exists; the singular would throw `Call to undefined method`
3. **Extended Example**: Added missing `use OpenFeature\OpenFeatureAPI;` import — the example calls `OpenFeatureAPI::getInstance()` but only imports `OpenFeatureClient`
4. **Provider extension example**: Added missing `use OpenFeature\implementation\provider\AbstractProvider;` import. Also aliased the `ResolutionDetails` import to `ResolutionDetailsInterface` to match the return type hints used throughout the example
5. **Hook development section**: Removed reference to non-existent `UnimplementedHook` "struct" (copied from Go SDK docs). Replaced with accurate description pointing to the typed abstract base classes (`BooleanHook`, `StringHook`, etc.) that PHP SDK actually provides. Fixed method name casing (`Before`/`After`/...) to match actual PHP method names (`before`/`after`/...)

All fixed examples were verified to execute successfully against the current main branch.